### PR TITLE
apply small cleanliness fixes

### DIFF
--- a/include/GeoTile/tile.hpp
+++ b/include/GeoTile/tile.hpp
@@ -30,4 +30,3 @@ private:
 };
 
 #endif
-

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -3,7 +3,7 @@
 
 #include <cmath>
 
-Point::Point(double latitude, double longitude) : latitude_(latitude), longitude_(longitude){};
+Point::Point(double latitude, double longitude) : latitude_(latitude), longitude_(longitude) {}
 
 Point Point::fromPixel(int pixelX, int pixelY, unsigned int zoom)
 {
@@ -18,7 +18,7 @@ Point Point::fromMeters(double meterX, double meterY)
     auto longitude = (meterX / ORIGIN_SHIFT) * 180.0;
     auto latitude = (meterY / ORIGIN_SHIFT) * 180.0;
     latitude = 180.0 / M_PI * (2 * atan(exp(latitude * M_PI / 180.0)) - M_PI / 2.0);
-    return Point(latitude, longitude);
+    return {latitude, longitude};
 }
 
 Point Point::fromLatLon(double latitude, double longitude)

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -4,16 +4,17 @@
 
 #include <algorithm>
 #include <sstream>
+#include <iterator>
 #include <vector>
 
-Tile::Tile(int tmsX, int tmsY, unsigned int zoom) : tmsX_(tmsX), tmsY_(tmsY), zoom_(zoom){};
+Tile::Tile(int tmsX, int tmsY, unsigned int zoom) : tmsX_(tmsX), tmsY_(tmsY), zoom_(zoom) {}
 
 Tile Tile::fromQuadTree(std::string quadTree)
 {
     int zoom = quadTree.size();
     auto offset = (1 << zoom) - 1;
 
-    std::vector<int> digits;
+    std::vector<int> digits{};
     std::for_each(quadTree.begin(), quadTree.end(), [&digits](char c) {
         int digit = c - '0';
         digits.push_back(digit);
@@ -35,7 +36,7 @@ Tile Tile::fromQuadTree(std::string quadTree)
 
 Tile Tile::fromTms(int tmsX, int tmsY, unsigned int zoom)
 {
-    return Tile{tmsX, tmsY, zoom};
+    return {tmsX, tmsY, zoom};
 }
 
 Tile Tile::fromGoogle(int googleX, int googleY, unsigned int zoom)
@@ -86,7 +87,7 @@ std::string Tile::getQuadTree()
 {
     int tmsX = tmsX_;
     int tmsY = (1 << (zoom_ - 1)) - tmsY_;
-    std::vector<int> digits;
+    std::vector<int> digits{};
     for (int i = zoom_; i > 0; i--)
     {
         int digit = 0;
@@ -105,7 +106,7 @@ std::string Tile::getQuadTree()
         }
         digits.push_back(digit);
     }
-    std::stringstream strStream;
+    std::stringstream strStream{};
     std::copy(digits.begin(), digits.end(), std::ostream_iterator<int>(strStream, ""));
     return strStream.str();
 }


### PR DESCRIPTION
* There were two stray semicolons
* The include of `<iterator>` was missing in tile.cpp, causing the build to
  break on gcc >= 10.1
* In some places, the initialization braces were missing. While the
  objects were technically correctly initialized, it was no obvious that
  they are.