### PR TITLE
clean up build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,7 @@
-cmake_minimum_required(VERSION 3.12)
-project(GeoTile LANGUAGES CXX)
+cmake_minimum_required(VERSION "3.12")
+project("GeoTile" LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-
-set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+include("GoogleTest")
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug")
@@ -14,41 +9,20 @@ endif()
 
 option(ENABLE_GEOTILETESTS "Builds the GeoTile GoogleTest suite." ON)
 
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  SET(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
-endif()
-
-set(
-  HEADERS
+add_library("${PROJECT_NAME}"
+  "src/point.cpp"
+  "src/tile.cpp"
   "include/GeoTile/meta.hpp"
   "include/GeoTile/point.hpp"
   "include/GeoTile/tile.hpp"
 )
 
-set(
-  SOURCES
-  "src/point.cpp"
-  "src/tile.cpp"
-)
-
-add_library(
-  "${PROJECT_NAME}"
-  SHARED
-  "${SOURCES}"
-  "${HEADERS}"
-)
-
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
+target_include_directories("${PROJECT_NAME}" PUBLIC
     $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
-target_compile_options(
-  "${PROJECT_NAME}"
-  PUBLIC
+target_compile_options("${PROJECT_NAME}" PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
     -Wall
     -Wextra
@@ -57,6 +31,44 @@ target_compile_options(
   >
 )
 
+target_compile_features("${PROJECT_NAME}" PUBLIC
+  "cxx_std_17"
+)
+
+set_target_properties("${PROJECT_NAME}" PROPERTIES
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  INTERPROCEDURAL_OPTIMIZATION ON
+  INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF
+)
+
 if (ENABLE_GEOTILETESTS)
-  add_subdirectory("tests")
+  enable_testing()
+
+  set(BUILD_GMOCK OFF CACHE INTERNAL "")
+  set(INSTALL_GTEST OFF CACHE INTERNAL "")
+
+  add_subdirectory("tests/thirdparty/googletest")
+
+  add_executable("${PROJECT_NAME}_tests"
+    "tests/src/main.cpp"
+    "tests/src/point.cpp"
+    "tests/src/tile.cpp"
+  )
+
+  target_link_libraries("${PROJECT_NAME}_tests" PRIVATE
+      "${PROJECT_NAME}"
+      "gtest"
+  )
+
+  target_compile_options("${PROJECT_NAME}_tests" PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+      -Wall
+      -Wextra
+      -Werror
+      -pedantic-errors
+    >
+  )
+
+  gtest_discover_tests("${PROJECT_NAME}_tests")
 endif()


### PR DESCRIPTION
* We don't want to force our consumers to a certain standard by setting
  the global CMAKE_CXX_STANDARD, as this might mean a downgrade for
  them. Thus we set the standard a feature on our library, allowing
  consumers to have different standard versions. The same holds for IPO
  and C++ extensions.
* There is no need to go through additional variables to define our
  sources. We don't gain anything from that aproach.
* Similarly, we don't gain any meaningful advantage from having our
  tests be a subproject of the library.
* This patchset also enables CTest auto-discovery for our tests.